### PR TITLE
Upd PopupAdapter: added "public" modfier

### DIFF
--- a/MapsV2/Popups/src/com/commonsware/android/mapsv2/popups/PopupAdapter.java
+++ b/MapsV2/Popups/src/com/commonsware/android/mapsv2/popups/PopupAdapter.java
@@ -20,7 +20,7 @@ import android.widget.TextView;
 import com.google.android.gms.maps.GoogleMap.InfoWindowAdapter;
 import com.google.android.gms.maps.model.Marker;
 
-class PopupAdapter implements InfoWindowAdapter {
+public class PopupAdapter implements InfoWindowAdapter {
   LayoutInflater inflater=null;
 
   PopupAdapter(LayoutInflater inflater) {


### PR DESCRIPTION
Without "public" modifier PopupAdapter is not available from other classes: "java: com.example.PopupAdapter is not public in com.example; cannot be accessed from outside package"
