### PR TITLE
Fix WebView.loadData() encoding

### DIFF
--- a/WebKit/Browser3/app/src/main/java/com/commonsware/android/webkit/BrowserDemo3.java
+++ b/WebKit/Browser3/app/src/main/java/com/commonsware/android/webkit/BrowserDemo3.java
@@ -42,7 +42,7 @@ public class BrowserDemo3 extends Activity {
                                            | DateUtils.FORMAT_SHOW_TIME)
             + "</a></body></html>";
 
-    browser.loadData(page, "text/html", "UTF-8");
+    browser.loadData(page, "text/html; charset=UTF-8", null);
   }
 
   private class Callback extends WebViewClient {


### PR DESCRIPTION
As [documentation says](https://developer.android.com/reference/android/webkit/WebView.html#loadData(java.lang.String,%20java.lang.String,%20java.lang.String)), the only valid value for 'encoding' parameter is 'base64', and any other value is treated as ASCII/hex encoding. This may cause non-ASCII characters in data to be incorrectly displayed:
![encoding_bug](https://user-images.githubusercontent.com/22061463/38459961-5624b1be-3ab9-11e8-8eb9-e953797d20cc.png)
Simplest way to specify UTF-8 encoding is via 'mimeType' parameter, as [proposed on SO](https://stackoverflow.com/a/9402988/9316168).