### PR TITLE
fix image was not shown in marker in some situations

### DIFF
--- a/MapsV2/ImagePopups/app/src/main/java/com/commonsware/android/mapsv2/imagepopups/PopupAdapter.java
+++ b/MapsV2/ImagePopups/app/src/main/java/com/commonsware/android/mapsv2/imagepopups/PopupAdapter.java
@@ -78,6 +78,7 @@ class PopupAdapter implements InfoWindowAdapter {
         icon.setVisibility(View.GONE);
       }
       else {
+        icon.setVisibility(View.VISIBLE);
         Picasso.with(ctxt).load(image).resize(iconWidth, iconHeight)
                .centerCrop().noFade()
                .placeholder(R.drawable.placeholder)


### PR DESCRIPTION
ImageView icon in layout popup is set to View.GONE and never set back to View.VISIBLE. Since layout popup instance is reused in all markers, this causes all the following markers can not show their images, even they have one. Fix this by setting ImageView icon to View.VISIBLE in due cause.